### PR TITLE
fix: getRadius -> getPointRadius

### DIFF
--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -719,7 +719,7 @@ declare module "@deck.gl/layers/geojson-layer/geojson-layer" {
 		//Data Accessors
 		getLineColor?: ((d: D) => RGBAColor) | RGBAColor;
 		getFillColor?: ((d: D) => RGBAColor) | RGBAColor;
-		getRadius?: ((d: D) => number) | number;
+		getPointRadius?: ((d: D) => number) | number;
 		getLineWidth?: ((d: D) => number) | number;
 		getElevation?: ((d: D) => number) | number;
 	}


### PR DESCRIPTION
https://deck.gl/docs/upgrade-guide#deprecations

GeoJsonLayer's getRadius props is deprecated, replaced by getPointRadius.